### PR TITLE
Issue #16 - implemented "/competitions/all" endpoint

### DIFF
--- a/web/src/components/common/api-football-logo/api-football-logo.tsx
+++ b/web/src/components/common/api-football-logo/api-football-logo.tsx
@@ -12,7 +12,7 @@ export const ApiFootballLogoComponent = (props: IApiFootballLogoComponentProps) 
             src={props.src}
             alt={props.alt}
             loading="lazy"
-            className={`object-cover ${props.width ? `w-[${props.width}px]` : "w-auto"} ${
+            className={`object-scale-down ${props.width ? `w-[${props.width}px]` : "w-auto"} ${
                 props.height ? `h-[${props.height}px]` : "h-auto"
             }`}
             style={{

--- a/web/src/components/common/api-football-response.ts
+++ b/web/src/components/common/api-football-response.ts
@@ -5,7 +5,7 @@ export type MatchEventType = "goal" | "card" | "subst" | "var";
  * ! Do NOT modify unless API Football has been updated. Need to match word casing !
  */
 
-export interface IMatchResponse {
+export interface IBaseResponse {
     errors: any[];
     get: string;
     paging: {
@@ -15,6 +15,11 @@ export interface IMatchResponse {
     parameters: {
         [key: string]: string;
     };
+}
+
+// Match Types
+
+export interface IMatchResponse extends IBaseResponse {
     response: IMatch[];
 }
 
@@ -175,4 +180,58 @@ export interface IMatchLineupPlayer {
     pos: string;
     grid: string;
     events?: IMatchEvent[];
+}
+
+// End Match Types
+
+// Competition (League) Types
+
+export interface ICompetitionResponse extends IBaseResponse {
+    response: ICompetition[];
+}
+
+export interface ICompetition {
+    league: ICompetitionLeague;
+    country: ICompetitionCountry;
+    seasons: ICompetitionSeason[];
+}
+
+export interface ICompetitionLeague {
+    id: number;
+    name: string;
+    type: string;
+    logo: string;
+}
+
+export interface ICompetitionCountry {
+    name: string;
+    code: string;
+    flag: string;
+}
+
+export interface ICompetitionSeason {
+    year: number;
+    start: string;
+    end: string;
+    current: boolean;
+    coverage: ICompetitionSeasonCoverage;
+}
+
+export interface ICompetitionSeasonCoverage {
+    fixtures: ICompetitionSeasonCoverageFixtures;
+    standings: boolean;
+    players: boolean;
+    top_scorers: boolean;
+    top_assists: boolean;
+    top_cards: boolean;
+    injuries: boolean;
+    predictions: boolean;
+    odds: boolean;
+}
+
+export interface ICompetitionSeasonCoverageFixtures {
+    events: boolean;
+    lineup: boolean;
+    statistics_fixtures: boolean;
+    statistics_players: boolean;
 }

--- a/web/src/components/common/back-navigation/back-navigation.tsx
+++ b/web/src/components/common/back-navigation/back-navigation.tsx
@@ -14,23 +14,23 @@ export const BackNavigationComponent = (props: IBackNavigationComponentProps) =>
     // determine if previous page was from ultrashub origin
     const isPreviousPageFromUH = document.referrer.includes(window.location.origin);
 
+    if (!isPreviousPageFromUH || !props.title) {
+        return <></>;
+    }
+
     return (
         <section className="h-[40px] flex flex-row items-center gap-2">
-            {isPreviousPageFromUH && (
-                <>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
-                                <ArrowLeftToLine />
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                            <p>Go back</p>
-                        </TooltipContent>
-                    </Tooltip>
-                    <Separator orientation="vertical" />
-                </>
-            )}
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
+                        <ArrowLeftToLine />
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <p>Go back</p>
+                </TooltipContent>
+            </Tooltip>
+            <Separator orientation="vertical" />
             <h3 className="font-bold">{props.title}</h3>
         </section>
     );

--- a/web/src/components/common/hooks/debounce.ts
+++ b/web/src/components/common/hooks/debounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+export const useDebounce = (value: string, delay: number) => {
+    const [debouncedValue, setDebouncedValue] = useState(value);
+
+    useEffect(() => {
+        const handler = setTimeout(() => {
+            setDebouncedValue(value);
+        }, delay);
+
+        return () => {
+            clearTimeout(handler);
+        };
+    }, [value, delay]);
+
+    return debouncedValue;
+};

--- a/web/src/components/common/types.ts
+++ b/web/src/components/common/types.ts
@@ -1,3 +1,5 @@
 export interface IProps {
     children?: React.ReactNode;
 }
+
+export const TOP_COMPS_IDS: number[] = [2, 3, 39, 45, 48, 61, 78, 135, 140, 253, 848];

--- a/web/src/components/features/competitions/competitions-item/competitions-item.tsx
+++ b/web/src/components/features/competitions/competitions-item/competitions-item.tsx
@@ -1,0 +1,40 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { ApiFootballLogoComponent } from "@/components/common/api-football-logo/api-football-logo";
+import { ICompetition } from "@/components/common/api-football-response";
+import { NavLink } from "react-router-dom";
+
+interface ICompetitionsItemComponentProps {
+    competition: ICompetition;
+}
+
+export const CompetitionsItemComponent = (props: ICompetitionsItemComponentProps) => {
+    return (
+        <NavLink key={props.competition.league.id} to={`/competitions/id/${props.competition.league.id}`}>
+            <Card className="hover:bg-muted">
+                <CardContent className="flex flex-row justify-between items-center p-3">
+                    <section className="flex gap-2 items-center">
+                        {props.competition.league.logo && (
+                            <ApiFootballLogoComponent
+                                src={props.competition.league.logo}
+                                alt={`${props.competition.league.name} logo`}
+                                width={30}
+                                height={30}
+                            />
+                        )}
+                        <h5>{props.competition.league.name}</h5>
+                    </section>
+                    {props.competition.country.flag && (
+                        <section className="opacity-60">
+                            <ApiFootballLogoComponent
+                                src={props.competition.country.flag}
+                                alt={`${props.competition.country.name} flag`}
+                                width={20}
+                                height={20}
+                            />
+                        </section>
+                    )}
+                </CardContent>
+            </Card>
+        </NavLink>
+    );
+};

--- a/web/src/components/features/competitions/competitions-search/competitions-search.tsx
+++ b/web/src/components/features/competitions/competitions-search/competitions-search.tsx
@@ -1,0 +1,54 @@
+import { ICompetition } from "@/components/common/api-football-response";
+import { useDebounce } from "@/components/common/hooks/debounce";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { X } from "lucide-react";
+import { useEffect, useState } from "react";
+
+interface ICompetitionsSearchComponentProps {
+    allCompetitions: ICompetition[];
+    setFilteredCompetitions: React.Dispatch<React.SetStateAction<ICompetition[]>>;
+}
+
+export const CompetitionsSearchComponent = (props: ICompetitionsSearchComponentProps) => {
+    const [searchTerm, setSearchTerm] = useState<string>("");
+    const debouncedValue = useDebounce(searchTerm, 200);
+
+    useEffect(() => {
+        console.log("Debounced value:", debouncedValue);
+        const newFilteredCompetitions = props.allCompetitions.filter((comp) => {
+            return comp.league.name.toLocaleLowerCase().includes(debouncedValue.toLocaleLowerCase());
+        });
+        props.setFilteredCompetitions(newFilteredCompetitions);
+    }, [debouncedValue]);
+
+    const handleOnChangeSearchTerm = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setSearchTerm(event.target.value);
+    };
+
+    const handleOnClickClearSearchTerm = () => {
+        setSearchTerm("");
+    };
+
+    return (
+        <section className="w-full flex items-center gap-2">
+            <Input
+                type="text"
+                placeholder="Search competitions"
+                value={searchTerm}
+                onChange={(evt) => handleOnChangeSearchTerm(evt)}
+            />
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button variant="outline" className="p-2" onClick={() => handleOnClickClearSearchTerm()}>
+                        <X />
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <p>Clear search input</p>
+                </TooltipContent>
+            </Tooltip>
+        </section>
+    );
+};

--- a/web/src/components/features/competitions/competitions.hooks.tsx
+++ b/web/src/components/features/competitions/competitions.hooks.tsx
@@ -1,10 +1,19 @@
-import { ICompetition, ICompetitionResponse } from "@/components/common/api-football-response";
-import axios from "@/lib/axios";
-import { AxiosResponse } from "axios";
 import { useEffect, useState } from "react";
+import { AxiosResponse } from "axios";
+import { ICompetition, ICompetitionResponse } from "@/components/common/api-football-response";
+import { TOP_COMPS_IDS } from "@/components/common/types";
+import axios from "@/lib/axios";
+
+interface ICompetitionsData {
+    allCompetitions: ICompetition[];
+    setAllCompetitions: React.Dispatch<React.SetStateAction<ICompetition[]>>;
+    filteredCompetitions: ICompetition[];
+    setFilteredCompetitions: React.Dispatch<React.SetStateAction<ICompetition[]>>;
+}
 
 export const useCompetitions = () => {
-    const [competitions, setCompetitions] = useState<ICompetition[] | null>(null);
+    const [allCompetitions, setAllCompetitions] = useState<ICompetition[]>([]);
+    const [filteredCompetitions, setFilteredCompetitions] = useState<ICompetition[]>([]);
     const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
 
     useEffect(() => {
@@ -20,7 +29,30 @@ export const useCompetitions = () => {
                 }
                 const newCompetitions = resp.data.response;
 
-                setCompetitions(newCompetitions);
+                const topCompetitions: ICompetition[] = [];
+                const nonTopCompetitions: ICompetition[] = [];
+
+                // group competitons by if it is a top com
+                newCompetitions.forEach((comp) => {
+                    TOP_COMPS_IDS.includes(comp.league.id) ? topCompetitions.push(comp) : nonTopCompetitions.push(comp);
+                });
+
+                // within each sub group of top and non-top comps, group by country name
+                topCompetitions.sort((a, b) => {
+                    const aCompName = `${a.country.name} ${a.league.name}`;
+                    const bCompName = `${b.country.name} ${b.league.name}`;
+                    return aCompName.localeCompare(bCompName);
+                });
+                nonTopCompetitions.sort((a, b) => {
+                    const aCompName = `${a.country.name} ${a.league.name}`;
+                    const bCompName = `${b.country.name} ${b.league.name}`;
+                    return aCompName.localeCompare(bCompName);
+                });
+
+                const competitionsDisplayList = [...topCompetitions, ...nonTopCompetitions];
+
+                setAllCompetitions(competitionsDisplayList);
+                setFilteredCompetitions(competitionsDisplayList);
                 setStatus("success");
             } catch (err) {
                 setStatus("error");
@@ -32,6 +64,15 @@ export const useCompetitions = () => {
 
     const isLoading = status === "loading";
     const isError = status === "error";
+    const data: ICompetitionsData | null =
+        isLoading || isError
+            ? null
+            : {
+                  allCompetitions,
+                  setAllCompetitions,
+                  filteredCompetitions,
+                  setFilteredCompetitions,
+              };
 
-    return [competitions, isLoading, isError] as const;
+    return [data, isLoading, isError] as const;
 };

--- a/web/src/components/features/competitions/competitions.hooks.tsx
+++ b/web/src/components/features/competitions/competitions.hooks.tsx
@@ -1,0 +1,37 @@
+import { ICompetition, ICompetitionResponse } from "@/components/common/api-football-response";
+import axios from "@/lib/axios";
+import { AxiosResponse } from "axios";
+import { useEffect, useState } from "react";
+
+export const useCompetitions = () => {
+    const [competitions, setCompetitions] = useState<ICompetition[] | null>(null);
+    const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+
+    useEffect(() => {
+        const fetchCompetitions = async () => {
+            try {
+                const resp = await axios.get<any, AxiosResponse<ICompetitionResponse>>("/apifootball/leagues", {
+                    params: {
+                        current: true,
+                    },
+                });
+                if (resp.status !== 200) {
+                    throw new Error();
+                }
+                const newCompetitions = resp.data.response;
+
+                setCompetitions(newCompetitions);
+                setStatus("success");
+            } catch (err) {
+                setStatus("error");
+            }
+        };
+
+        fetchCompetitions();
+    }, []);
+
+    const isLoading = status === "loading";
+    const isError = status === "error";
+
+    return [competitions, isLoading, isError] as const;
+};

--- a/web/src/components/features/competitions/competitions.tsx
+++ b/web/src/components/features/competitions/competitions.tsx
@@ -1,18 +1,17 @@
 import { Spinner } from "@/components/ui/spinner";
 import { ErrorComponent } from "@/components/common/error/error";
 import { useCompetitions } from "./competitions.hooks";
-import { ICompetition } from "@/components/common/api-football-response";
-import { TOP_COMPS_IDS } from "../matches/matches.types";
 import { CompetitionsItemComponent } from "./competitions-item/competitions-item";
+import { CompetitionsSearchComponent } from "./competitions-search/competitions-search";
 
 export const CompetitionsComponent = () => {
-    const [competitions, isLoading, isError] = useCompetitions();
+    const [data, isLoading, isError] = useCompetitions();
 
     if (isLoading) {
         return <Spinner />;
     }
 
-    if (isError || !competitions) {
+    if (isError || !data) {
         return (
             <ErrorComponent
                 backNavTitle="Error!"
@@ -20,37 +19,23 @@ export const CompetitionsComponent = () => {
             />
         );
     }
-
-    const topCompetitions: ICompetition[] = [];
-    const nonTopCompetitions: ICompetition[] = [];
-
-    // group competitons by if it is a top com
-    competitions.forEach((comp) => {
-        TOP_COMPS_IDS.includes(comp.league.id) ? topCompetitions.push(comp) : nonTopCompetitions.push(comp);
-    });
-
-    // within each sub group of top and non-top comps, group by country name
-    topCompetitions.sort((a, b) => {
-        const aCompName = `${a.country.name} ${a.league.name}`;
-        const bCompName = `${b.country.name} ${b.league.name}`;
-        return aCompName.localeCompare(bCompName);
-    });
-    nonTopCompetitions.sort((a, b) => {
-        const aCompName = `${a.country.name} ${a.league.name}`;
-        const bCompName = `${b.country.name} ${b.league.name}`;
-        return aCompName.localeCompare(bCompName);
-    });
-
-    const competitionsDisplayList = [...topCompetitions, ...nonTopCompetitions];
-
     return (
-        <section className="overflow-hidden">
-            <h3 className="text-2xl font-bold mb-5">All Competitions</h3>
+        <section className="space-y-5">
+            <h3 className="text-2xl font-bold">All Competitions</h3>
+
+            <CompetitionsSearchComponent
+                allCompetitions={data.allCompetitions}
+                setFilteredCompetitions={data.setFilteredCompetitions}
+            />
 
             <section className="grid grid-cols-1 lg:grid-cols-3 gap-1">
-                {competitionsDisplayList.map((competition) => (
-                    <CompetitionsItemComponent competition={competition} key={competition.league.id} />
-                ))}
+                {data.filteredCompetitions.length > 0 ? (
+                    data.filteredCompetitions.map((competition) => (
+                        <CompetitionsItemComponent competition={competition} key={competition.league.id} />
+                    ))
+                ) : (
+                    <ErrorComponent errorMessage="Wow, such empty" />
+                )}
             </section>
         </section>
     );

--- a/web/src/components/features/competitions/competitions.tsx
+++ b/web/src/components/features/competitions/competitions.tsx
@@ -1,0 +1,57 @@
+import { Spinner } from "@/components/ui/spinner";
+import { ErrorComponent } from "@/components/common/error/error";
+import { useCompetitions } from "./competitions.hooks";
+import { ICompetition } from "@/components/common/api-football-response";
+import { TOP_COMPS_IDS } from "../matches/matches.types";
+import { CompetitionsItemComponent } from "./competitions-item/competitions-item";
+
+export const CompetitionsComponent = () => {
+    const [competitions, isLoading, isError] = useCompetitions();
+
+    if (isLoading) {
+        return <Spinner />;
+    }
+
+    if (isError || !competitions) {
+        return (
+            <ErrorComponent
+                backNavTitle="Error!"
+                errorMessage="No competitions data was found. Refresh the page or try again later."
+            />
+        );
+    }
+
+    const topCompetitions: ICompetition[] = [];
+    const nonTopCompetitions: ICompetition[] = [];
+
+    // group competitons by if it is a top com
+    competitions.forEach((comp) => {
+        TOP_COMPS_IDS.includes(comp.league.id) ? topCompetitions.push(comp) : nonTopCompetitions.push(comp);
+    });
+
+    // within each sub group of top and non-top comps, group by country name
+    topCompetitions.sort((a, b) => {
+        const aCompName = `${a.country.name} ${a.league.name}`;
+        const bCompName = `${b.country.name} ${b.league.name}`;
+        return aCompName.localeCompare(bCompName);
+    });
+    nonTopCompetitions.sort((a, b) => {
+        const aCompName = `${a.country.name} ${a.league.name}`;
+        const bCompName = `${b.country.name} ${b.league.name}`;
+        return aCompName.localeCompare(bCompName);
+    });
+
+    const competitionsDisplayList = [...topCompetitions, ...nonTopCompetitions];
+
+    return (
+        <section className="overflow-hidden">
+            <h3 className="text-2xl font-bold mb-5">All Competitions</h3>
+
+            <section className="grid grid-cols-1 lg:grid-cols-3 gap-1">
+                {competitionsDisplayList.map((competition) => (
+                    <CompetitionsItemComponent competition={competition} key={competition.league.id} />
+                ))}
+            </section>
+        </section>
+    );
+};

--- a/web/src/components/features/matches/matches-list/matches-list-filters/matches-list-filters.tsx
+++ b/web/src/components/features/matches/matches-list/matches-list-filters/matches-list-filters.tsx
@@ -11,19 +11,19 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { ALL_COMPS, ALL_TEAMS, ICompetition, ITeam } from "../../matches.types";
+import { ALL_MATCHES_COMPS, ALL_MATCHES_TEAMS, IMatchesCompetition, IMatchesTeam } from "../../matches.types";
 import { cn } from "@/lib/shadcn";
 import { DateToolbox } from "@/components/common/toolbox/date";
 import { ApiFootballLogoComponent } from "@/components/common/api-football-logo/api-football-logo";
 
 interface IMatchesListFiltersComponentProps extends IProps {
     date: Date;
-    competitions: ICompetition[];
-    selectedCompetition: ICompetition;
-    setSelectedCompetition: React.Dispatch<React.SetStateAction<ICompetition>>;
-    teams: ITeam[];
-    selectedTeam: ITeam;
-    setSelectedTeam: React.Dispatch<React.SetStateAction<ITeam>>;
+    competitions: IMatchesCompetition[];
+    selectedCompetition: IMatchesCompetition;
+    setSelectedCompetition: React.Dispatch<React.SetStateAction<IMatchesCompetition>>;
+    teams: IMatchesTeam[];
+    selectedTeam: IMatchesTeam;
+    setSelectedTeam: React.Dispatch<React.SetStateAction<IMatchesTeam>>;
     defaultShowScores: boolean;
     showScores: boolean;
     setShowScores: React.Dispatch<React.SetStateAction<boolean>>;
@@ -44,7 +44,7 @@ export const MatchesListFiltersComponent = (props: IMatchesListFiltersComponentP
         setIsDatePickerPopoverOpen(false);
     };
 
-    const onSelectCompetitionChange = (value: string, competition: ICompetition) => {
+    const onSelectCompetitionChange = (value: string, competition: IMatchesCompetition) => {
         setIsCompetitionSelectPopoverOpen(false);
         // if users selects the competition that is already selected, deselect it
         if (value.toLocaleUpperCase() === props.selectedCompetition.displayName.toLocaleUpperCase()) {
@@ -54,7 +54,7 @@ export const MatchesListFiltersComponent = (props: IMatchesListFiltersComponentP
         props.setSelectedCompetition(competition);
     };
 
-    const onSelectTeamChange = (value: string, team: ITeam) => {
+    const onSelectTeamChange = (value: string, team: IMatchesTeam) => {
         setIsTeamSelectPopoverOpen(false);
         // if users selects the team that is already selected, deselect it
         if (value.toLocaleUpperCase() === props.selectedTeam.name.toLocaleUpperCase()) {
@@ -68,12 +68,12 @@ export const MatchesListFiltersComponent = (props: IMatchesListFiltersComponentP
         props.setShowScores(props.defaultShowScores);
         // by resetting competition selection, we also reset filtered teams selection back to ALL_TEAMS
         if (props.selectedCompetition.id !== 0) {
-            onSelectCompetitionChange(ALL_COMPS, props.competitions[0]);
+            onSelectCompetitionChange(ALL_MATCHES_COMPS, props.competitions[0]);
             return;
         }
         // only need to directly reset team selection when no competition is selected
         if (props.selectedTeam.id !== 0) {
-            onSelectTeamChange(ALL_TEAMS, props.teams[0]);
+            onSelectTeamChange(ALL_MATCHES_TEAMS, props.teams[0]);
             return;
         }
     };

--- a/web/src/components/features/matches/matches-list/matches-list.hooks.tsx
+++ b/web/src/components/features/matches/matches-list/matches-list.hooks.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { AxiosResponse } from "axios";
 import { IMatchResponse } from "@/components/common/api-football-response";
 import axios from "@/lib/axios";
-import { ALL_COMPS, ALL_TEAMS, ICompetition, IMatches, ITeam } from "../matches.types";
+import { ALL_MATCHES_COMPS, ALL_MATCHES_TEAMS, IMatchesCompetition, IMatches, IMatchesTeam } from "../matches.types";
 import { findMatchByTeamID } from "../matches.utils";
 import { DateToolbox } from "@/components/common/toolbox/date";
 
@@ -13,16 +13,16 @@ interface IMatchListData {
     setAllMatches: React.Dispatch<React.SetStateAction<IMatches[]>>;
     filteredMatches: IMatches[];
     setFilteredMatches: React.Dispatch<React.SetStateAction<IMatches[]>>;
-    allCompetitions: ICompetition[];
-    setAllCompetitions: React.Dispatch<React.SetStateAction<ICompetition[]>>;
-    selectedCompetition: ICompetition;
-    setSelectedCompetition: React.Dispatch<React.SetStateAction<ICompetition>>;
-    allTeams: ITeam[];
-    setAllTeams: React.Dispatch<React.SetStateAction<ITeam[]>>;
-    filteredTeams: ITeam[];
-    setFilteredTeams: React.Dispatch<React.SetStateAction<ITeam[]>>;
-    selectedTeam: ITeam;
-    setSelectedTeam: React.Dispatch<React.SetStateAction<ITeam>>;
+    allCompetitions: IMatchesCompetition[];
+    setAllCompetitions: React.Dispatch<React.SetStateAction<IMatchesCompetition[]>>;
+    selectedCompetition: IMatchesCompetition;
+    setSelectedCompetition: React.Dispatch<React.SetStateAction<IMatchesCompetition>>;
+    allTeams: IMatchesTeam[];
+    setAllTeams: React.Dispatch<React.SetStateAction<IMatchesTeam[]>>;
+    filteredTeams: IMatchesTeam[];
+    setFilteredTeams: React.Dispatch<React.SetStateAction<IMatchesTeam[]>>;
+    selectedTeam: IMatchesTeam;
+    setSelectedTeam: React.Dispatch<React.SetStateAction<IMatchesTeam>>;
     defaultShowScores: boolean;
     showScores: boolean;
     setShowScores: React.Dispatch<React.SetStateAction<boolean>>;
@@ -49,15 +49,17 @@ export const useMatchList = (date?: string) => {
     // matches filtered based on user selected filters
     const [filteredMatches, setFilteredMatches] = useState<IMatches[]>([]);
     // all unique competitions
-    const [allCompetitions, setAllCompetitions] = useState<ICompetition[]>([{ id: 0, displayName: ALL_COMPS }]);
+    const [allCompetitions, setAllCompetitions] = useState<IMatchesCompetition[]>([
+        { id: 0, displayName: ALL_MATCHES_COMPS },
+    ]);
     // store filter by Competition selection
-    const [selectedCompetition, setSelectedCompetition] = useState<ICompetition>(allCompetitions[0]);
+    const [selectedCompetition, setSelectedCompetition] = useState<IMatchesCompetition>(allCompetitions[0]);
     // all unique teams
-    const [allTeams, setAllTeams] = useState<ITeam[]>([{ id: 0, leagueID: 0, name: ALL_TEAMS }]);
+    const [allTeams, setAllTeams] = useState<IMatchesTeam[]>([{ id: 0, leagueID: 0, name: ALL_MATCHES_TEAMS }]);
     // filtered teams based on selectedCompetition
-    const [filteredTeams, setFilteredTeams] = useState<ITeam[]>(allTeams);
+    const [filteredTeams, setFilteredTeams] = useState<IMatchesTeam[]>(allTeams);
     // store filter by teams selection
-    const [selectedTeam, setSelectedTeam] = useState<ITeam>(allTeams[0]);
+    const [selectedTeam, setSelectedTeam] = useState<IMatchesTeam>(allTeams[0]);
     // track if user wants to see scores, only used when selectedDate === currentDate
     const [showScores, setShowScores] = useState<boolean>(defaultShowScores);
 
@@ -77,14 +79,14 @@ export const useMatchList = (date?: string) => {
                 });
 
                 const newMatchesArr: IMatches[] = [];
-                const newCompetitionsArr: ICompetition[] = [];
-                const newTeamsArr: ITeam[] = [];
+                const newCompetitionsArr: IMatchesCompetition[] = [];
+                const newTeamsArr: IMatchesTeam[] = [];
                 resp.data.response.forEach((match) => {
                     const competitionID = match.league.id;
                     // generate unique competitions array
                     const foundLeagueIDIndex = newCompetitionsArr.findIndex((comp) => comp.id === competitionID);
                     if (foundLeagueIDIndex === -1) {
-                        const newComp: ICompetition = {
+                        const newComp: IMatchesCompetition = {
                             id: competitionID,
                             displayName: `${match.league.country} ${match.league.name}`,
                             logo: match.league.logo,
@@ -95,7 +97,7 @@ export const useMatchList = (date?: string) => {
                     let teamID = match.teams.away.id;
                     let foundTeamIDIndex = newTeamsArr.findIndex((team) => team.id === teamID);
                     if (foundTeamIDIndex === -1) {
-                        const newTeam: ITeam = {
+                        const newTeam: IMatchesTeam = {
                             id: teamID,
                             leagueID: competitionID,
                             name: match.teams.away.name,
@@ -106,7 +108,7 @@ export const useMatchList = (date?: string) => {
                     teamID = match.teams.home.id;
                     foundTeamIDIndex = newTeamsArr.findIndex((team) => team.id === teamID);
                     if (foundTeamIDIndex === -1) {
-                        const newTeam: ITeam = {
+                        const newTeam: IMatchesTeam = {
                             id: teamID,
                             leagueID: competitionID,
                             name: match.teams.home.name,
@@ -132,12 +134,12 @@ export const useMatchList = (date?: string) => {
                 setFilteredMatches(newMatchesArr);
 
                 newCompetitionsArr.sort((a, b) => a.displayName.localeCompare(b.displayName));
-                newCompetitionsArr.unshift({ id: 0, displayName: ALL_COMPS });
+                newCompetitionsArr.unshift({ id: 0, displayName: ALL_MATCHES_COMPS });
                 setAllCompetitions(newCompetitionsArr);
                 setSelectedCompetition(newCompetitionsArr[0]);
 
                 newTeamsArr.sort((a, b) => a.name.localeCompare(b.name));
-                newTeamsArr.unshift({ id: 0, leagueID: 0, name: ALL_TEAMS });
+                newTeamsArr.unshift({ id: 0, leagueID: 0, name: ALL_MATCHES_TEAMS });
                 setAllTeams(newTeamsArr);
                 setFilteredTeams(newTeamsArr);
                 setSelectedTeam(newTeamsArr[0]);
@@ -151,7 +153,7 @@ export const useMatchList = (date?: string) => {
 
     // update filteredMatches, filterTeams, and selectedTeam based on selectedCompetition
     useEffect(() => {
-        // user selected ALL_COMPS, reset to show all available options
+        // user selected ALL_MATCH_COMPS, reset to show all available options
         if (selectedCompetition.id === 0) {
             setFilteredMatches(allMatches);
             setFilteredTeams(allTeams);
@@ -168,7 +170,7 @@ export const useMatchList = (date?: string) => {
 
         // get teams for the respective selectedCompetition.id
         const foundTeams = allTeams.filter((team) => team.leagueID === selectedCompetition.id);
-        foundTeams.unshift({ id: 0, leagueID: 0, name: ALL_TEAMS });
+        foundTeams.unshift({ id: 0, leagueID: 0, name: ALL_MATCHES_TEAMS });
         setFilteredTeams(foundTeams);
 
         // reset selectedTeam to ALL_TEAMS. Only occurs when user first selects a team and then selects

--- a/web/src/components/features/matches/matches-list/matches-list.tsx
+++ b/web/src/components/features/matches/matches-list/matches-list.tsx
@@ -1,4 +1,4 @@
-import { IProps } from "@/components/common/types";
+import { IProps, TOP_COMPS_IDS } from "@/components/common/types";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Separator } from "@/components/ui/separator";
 import { MatchesListFiltersComponent } from "./matches-list-filters/matches-list-filters";
@@ -7,7 +7,7 @@ import VirtualScroller from "virtual-scroller/react";
 import { Spinner } from "@/components/ui/spinner";
 import { useMatchList } from "./matches-list.hooks";
 import { ErrorComponent } from "@/components/common/error/error";
-import { IMatches, TOP_COMPS_IDS } from "../matches.types";
+import { IMatches } from "../matches.types";
 
 interface IMatchesListComponentProps extends IProps {
     date: string | undefined;

--- a/web/src/components/features/matches/matches.types.ts
+++ b/web/src/components/features/matches/matches.types.ts
@@ -1,17 +1,15 @@
 import { IMatch } from "@/components/common/api-football-response";
 
-export const ALL_COMPS = "All Competitions";
-export const ALL_TEAMS = "All Teams";
+export const ALL_MATCHES_COMPS = "All Competitions";
+export const ALL_MATCHES_TEAMS = "All Teams";
 
-export const TOP_COMPS_IDS: number[] = [2, 3, 39, 45, 48, 61, 78, 135, 140, 253, 848];
-
-export interface ICompetition {
+export interface IMatchesCompetition {
     id: number;
     displayName: string;
     logo?: string;
 }
 
-export interface ITeam {
+export interface IMatchesTeam {
     id: number;
     leagueID: number;
     name: string;

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/shadcn"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -1,25 +1,22 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/shadcn"
+import { cn } from "@/lib/shadcn";
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
     return (
-      <input
-        type={type}
-        className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Input.displayName = "Input"
+        <input
+            type={type}
+            className={cn(
+                "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+                className,
+            )}
+            ref={ref}
+            {...props}
+        />
+    );
+});
+Input.displayName = "Input";
 
-export { Input }
+export { Input };

--- a/web/src/components/ui/progress.tsx
+++ b/web/src/components/ui/progress.tsx
@@ -1,26 +1,23 @@
-import * as React from "react"
-import * as ProgressPrimitive from "@radix-ui/react-progress"
+import * as React from "react";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
 
-import { cn } from "@/lib/shadcn"
+import { cn } from "@/lib/shadcn";
 
 const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+    React.ElementRef<typeof ProgressPrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
 >(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
-      className
-    )}
-    {...props}
-  >
-    <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-    />
-  </ProgressPrimitive.Root>
-))
-Progress.displayName = ProgressPrimitive.Root.displayName
+    <ProgressPrimitive.Root
+        ref={ref}
+        className={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
+        {...props}
+    >
+        <ProgressPrimitive.Indicator
+            className="h-full w-full flex-1 bg-primary transition-all"
+            style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+        />
+    </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
 
-export { Progress }
+export { Progress };

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,138 +1,105 @@
-import * as React from "react"
-import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
 
-import { cn } from "@/lib/shadcn"
+import { cn } from "@/lib/shadcn";
 
-const Sheet = SheetPrimitive.Root
+const Sheet = SheetPrimitive.Root;
 
-const SheetTrigger = SheetPrimitive.Trigger
+const SheetTrigger = SheetPrimitive.Trigger;
 
-const SheetClose = SheetPrimitive.Close
+const SheetClose = SheetPrimitive.Close;
 
-const SheetPortal = SheetPrimitive.Portal
+const SheetPortal = SheetPrimitive.Portal;
 
 const SheetOverlay = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+    React.ElementRef<typeof SheetPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <SheetPrimitive.Overlay
-    className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
-    )}
-    {...props}
-    ref={ref}
-  />
-))
-SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+    <SheetPrimitive.Overlay
+        className={cn(
+            "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            className,
+        )}
+        {...props}
+        ref={ref}
+    />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
-  {
-    variants: {
-      side: {
-        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
-        bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
-        right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
-      },
+    "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+    {
+        variants: {
+            side: {
+                top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+                bottom: "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+                left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+                right: "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+            },
+        },
+        defaultVariants: {
+            side: "right",
+        },
     },
-    defaultVariants: {
-      side: "right",
-    },
-  }
-)
+);
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+        VariantProps<typeof sheetVariants> {}
 
-const SheetContent = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Content>,
-  SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side }), className)}
-      {...props}
-    >
-      {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-    </SheetPrimitive.Content>
-  </SheetPortal>
-))
-SheetContent.displayName = SheetPrimitive.Content.displayName
+const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
+    ({ side = "right", className, children, ...props }, ref) => (
+        <SheetPortal>
+            <SheetOverlay />
+            <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+                {children}
+                <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+                    <X className="h-4 w-4" />
+                    <span className="sr-only">Close</span>
+                </SheetPrimitive.Close>
+            </SheetPrimitive.Content>
+        </SheetPortal>
+    ),
+);
+SheetContent.displayName = SheetPrimitive.Content.displayName;
 
-const SheetHeader = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
-      className
-    )}
-    {...props}
-  />
-)
-SheetHeader.displayName = "SheetHeader"
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+);
+SheetHeader.displayName = "SheetHeader";
 
-const SheetFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-)
-SheetFooter.displayName = "SheetFooter"
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+);
+SheetFooter.displayName = "SheetFooter";
 
 const SheetTitle = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+    React.ElementRef<typeof SheetPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <SheetPrimitive.Title
-    ref={ref}
-    className={cn("text-lg font-semibold text-foreground", className)}
-    {...props}
-  />
-))
-SheetTitle.displayName = SheetPrimitive.Title.displayName
+    <SheetPrimitive.Title ref={ref} className={cn("text-lg font-semibold text-foreground", className)} {...props} />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
 
 const SheetDescription = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+    React.ElementRef<typeof SheetPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <SheetPrimitive.Description
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-SheetDescription.displayName = SheetPrimitive.Description.displayName
+    <SheetPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
 
 export {
-  Sheet,
-  SheetPortal,
-  SheetOverlay,
-  SheetTrigger,
-  SheetClose,
-  SheetContent,
-  SheetHeader,
-  SheetFooter,
-  SheetTitle,
-  SheetDescription,
-}
+    Sheet,
+    SheetPortal,
+    SheetOverlay,
+    SheetTrigger,
+    SheetClose,
+    SheetContent,
+    SheetHeader,
+    SheetFooter,
+    SheetTitle,
+    SheetDescription,
+};

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,117 +1,76 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/shadcn"
+import { cn } from "@/lib/shadcn";
 
-const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
-))
-Table.displayName = "Table"
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+    ({ className, ...props }, ref) => (
+        <div className="relative w-full overflow-auto">
+            <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+        </div>
+    ),
+);
+Table.displayName = "Table";
 
-const TableHeader = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
-))
-TableHeader.displayName = "TableHeader"
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+    ({ className, ...props }, ref) => <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />,
+);
+TableHeader.displayName = "TableHeader";
 
-const TableBody = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
-))
-TableBody.displayName = "TableBody"
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+    ({ className, ...props }, ref) => (
+        <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+    ),
+);
+TableBody.displayName = "TableBody";
 
-const TableFooter = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tfoot
-    ref={ref}
-    className={cn(
-      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-      className
-    )}
-    {...props}
-  />
-))
-TableFooter.displayName = "TableFooter"
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+    ({ className, ...props }, ref) => (
+        <tfoot
+            ref={ref}
+            className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
+            {...props}
+        />
+    ),
+);
+TableFooter.displayName = "TableFooter";
 
-const TableRow = React.forwardRef<
-  HTMLTableRowElement,
-  React.HTMLAttributes<HTMLTableRowElement>
->(({ className, ...props }, ref) => (
-  <tr
-    ref={ref}
-    className={cn(
-      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
-      className
-    )}
-    {...props}
-  />
-))
-TableRow.displayName = "TableRow"
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+    ({ className, ...props }, ref) => (
+        <tr
+            ref={ref}
+            className={cn("border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted", className)}
+            {...props}
+        />
+    ),
+);
+TableRow.displayName = "TableRow";
 
-const TableHead = React.forwardRef<
-  HTMLTableCellElement,
-  React.ThHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-  <th
-    ref={ref}
-    className={cn(
-      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
-      className
-    )}
-    {...props}
-  />
-))
-TableHead.displayName = "TableHead"
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+    ({ className, ...props }, ref) => (
+        <th
+            ref={ref}
+            className={cn(
+                "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+                className,
+            )}
+            {...props}
+        />
+    ),
+);
+TableHead.displayName = "TableHead";
 
-const TableCell = React.forwardRef<
-  HTMLTableCellElement,
-  React.TdHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-  <td
-    ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
-    {...props}
-  />
-))
-TableCell.displayName = "TableCell"
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+    ({ className, ...props }, ref) => (
+        <td ref={ref} className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)} {...props} />
+    ),
+);
+TableCell.displayName = "TableCell";
 
-const TableCaption = React.forwardRef<
-  HTMLTableCaptionElement,
-  React.HTMLAttributes<HTMLTableCaptionElement>
->(({ className, ...props }, ref) => (
-  <caption
-    ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-TableCaption.displayName = "TableCaption"
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
+    ({ className, ...props }, ref) => (
+        <caption ref={ref} className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
+    ),
+);
+TableCaption.displayName = "TableCaption";
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-}
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -1,53 +1,53 @@
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
 
-import { cn } from "@/lib/shadcn"
+import { cn } from "@/lib/shadcn";
 
-const Tabs = TabsPrimitive.Root
+const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+    React.ElementRef<typeof TabsPrimitive.List>,
+    React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
-      className
-    )}
-    {...props}
-  />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+    <TabsPrimitive.List
+        ref={ref}
+        className={cn(
+            "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+            className,
+        )}
+        {...props}
+    />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+    React.ElementRef<typeof TabsPrimitive.Trigger>,
+    React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
-      className
-    )}
-    {...props}
-  />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+    <TabsPrimitive.Trigger
+        ref={ref}
+        className={cn(
+            "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+            className,
+        )}
+        {...props}
+    />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+    React.ElementRef<typeof TabsPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
-    )}
-    {...props}
-  />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+    <TabsPrimitive.Content
+        ref={ref}
+        className={cn(
+            "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            className,
+        )}
+        {...props}
+    />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/web/src/layouts/navbar/navbar.tsx
+++ b/web/src/layouts/navbar/navbar.tsx
@@ -11,12 +11,14 @@ import {
     Menu,
     ShieldCheck,
     Trophy,
+    View,
 } from "lucide-react";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { ThemeToggleComponent } from "./theme-toggle/theme-toggle";
 import ultrashubLogo from "@/assets/img/logo.png";
+import { ApiFootballLogoComponent } from "@/components/common/api-football-logo/api-football-logo";
 
 export const NavbarComponent = () => {
     const [isSheetOpen, setIsSheetOpen] = useState<boolean>(false);
@@ -47,6 +49,73 @@ export const NavbarComponent = () => {
     );
 };
 
+interface ICompetitionNavLink {
+    to: string;
+    logo: string;
+    name: string;
+}
+
+const topLeagues: ICompetitionNavLink[] = [
+    {
+        to: "/competitions/id/39",
+        logo: "https://media.api-sports.io/football/leagues/39.png",
+        name: "Premier League",
+    },
+    {
+        to: "/competitions/id/140",
+        logo: "https://media.api-sports.io/football/leagues/140.png",
+        name: "La Liga",
+    },
+    {
+        to: "/competitions/id/78",
+        logo: "https://media.api-sports.io/football/leagues/78.png",
+        name: "Bundesliga",
+    },
+    {
+        to: "/competitions/id/135",
+        logo: "https://media.api-sports.io/football/leagues/135.png",
+        name: "Serie A",
+    },
+    {
+        to: "/competitions/id/61",
+        logo: "https://media.api-sports.io/football/leagues/61.png",
+        name: "Ligue Un",
+    },
+    {
+        to: "/competitions/id/253",
+        logo: "https://media.api-sports.io/football/leagues/253.png",
+        name: "MLS",
+    },
+];
+
+const topCups: ICompetitionNavLink[] = [
+    {
+        to: "/competitions/id/2",
+        logo: "https://media.api-sports.io/football/leagues/2.png",
+        name: "UEFA Champions League",
+    },
+    {
+        to: "/competitions/id/3",
+        logo: "https://media.api-sports.io/football/leagues/3.png",
+        name: "UEFA Europa League",
+    },
+    {
+        to: "/competitions/id/848",
+        logo: "https://media.api-sports.io/football/leagues/848.png",
+        name: "UEFA Europa Conference League",
+    },
+    {
+        to: "/competitions/id/45",
+        logo: "https://media.api-sports.io/football/leagues/45.png",
+        name: "FA Cup",
+    },
+    {
+        to: "/competitions/id/48",
+        logo: "https://media.api-sports.io/football/leagues/48.png",
+        name: "Carabao Cup",
+    },
+];
+
 interface INavbarNavComponentProps {
     setIsSheetOpen?: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -74,16 +143,66 @@ const NavbarNavContentComponent = (props: INavbarNavComponentProps) => {
                         <Calendar />
                         Matches
                     </NavLink>
-                    <NavLink
-                        to="/"
-                        className="flex gap-2 items-center w-full p-2 rounded-md hover:bg-muted"
-                        onClick={() => closeSheet()}
-                    >
-                        <Trophy />
-                        Competitions
-                    </NavLink>
                     <Accordion type="single" collapsible className="p-0">
-                        <AccordionItem value="item-1" className="border-0">
+                        <AccordionItem value="competitions" className="border-0">
+                            <AccordionTrigger className="p-2 rounded-md hover:bg-muted hover:no-underline">
+                                <section className="flex gap-2 items-center ">
+                                    <Trophy />
+                                    Competitions
+                                </section>
+                            </AccordionTrigger>
+                            <AccordionContent>
+                                <NavLink
+                                    to="/competitions/all"
+                                    className="flex gap-2 items-center w-full p-2 rounded-md hover:bg-muted"
+                                    onClick={() => closeSheet()}
+                                >
+                                    <View className="h-4 2-4" />
+                                    View all competitions
+                                </NavLink>
+                                <section className="w-full flex flex-col items-start gap-2">
+                                    <section className="w-full flex flex-col items-start gap-2">
+                                        <p className="w-full pl-2 font-light">Top Leagues</p>
+                                        {topLeagues.map((league) => (
+                                            <NavLink
+                                                key={league.name}
+                                                to={league.to}
+                                                className="flex gap-2 items-center w-full p-2 rounded-md hover:bg-muted"
+                                                onClick={() => closeSheet()}
+                                            >
+                                                <ApiFootballLogoComponent
+                                                    src={league.logo}
+                                                    alt={`${league.name} logo`}
+                                                    width={20}
+                                                    height={20}
+                                                />
+                                                {league.name}
+                                            </NavLink>
+                                        ))}
+                                    </section>
+                                    <section className="w-full flex flex-col items-start gap-2">
+                                        <p className="w-full pl-2 font-light">Top Cups</p>
+                                        {topCups.map((cup) => (
+                                            <NavLink
+                                                key={cup.name}
+                                                to={cup.to}
+                                                className="flex gap-2 items-center w-full p-2 rounded-md hover:bg-muted"
+                                                onClick={() => closeSheet()}
+                                            >
+                                                <ApiFootballLogoComponent
+                                                    src={cup.logo}
+                                                    alt={`${cup.name} logo`}
+                                                    width={20}
+                                                    height={20}
+                                                />
+                                                {cup.name}
+                                            </NavLink>
+                                        ))}
+                                    </section>
+                                </section>
+                            </AccordionContent>
+                        </AccordionItem>
+                        <AccordionItem value="more" className="border-0">
                             <AccordionTrigger className="p-2 rounded-md hover:bg-muted hover:no-underline">
                                 <section className="flex gap-2 items-center ">
                                     <Info />

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,6 +11,7 @@ import { SecurityPolicyPage } from "@/pages/policies/security";
 import { PrivacyPolicyPage } from "@/pages/policies/privacy";
 import { NotFoundPage } from "@/pages/not-found";
 import "./main.css";
+import { CompetitionsPage } from "./pages/competitions";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
@@ -28,6 +29,8 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
                             <Route path="/" element={<MatchesPage />} />
                             <Route path="/matches/date/:date?" element={<MatchesPage />} />
                             <Route path="/match/id/:id" element={<MatchPage />} />
+                            <Route path="/competitions/all" element={<CompetitionsPage />} />
+                            <Route path="/competitions/id/:id" element={<NotFoundPage />} />
                             <Route path="/policies/terms-of-service" element={<TermsOfServicePage />} />
                             <Route path="/policies/security" element={<SecurityPolicyPage />} />
                             <Route path="/policies/privacy" element={<PrivacyPolicyPage />} />

--- a/web/src/pages/competitions.tsx
+++ b/web/src/pages/competitions.tsx
@@ -1,0 +1,9 @@
+import { CompetitionsComponent } from "@/components/features/competitions/competitions";
+
+export const CompetitionsPage = () => {
+    return (
+        <>
+            <CompetitionsComponent />
+        </>
+    );
+};


### PR DESCRIPTION
closes #16 

- [x] Add "Competitions" navbar nav link option that is a dropdown menu that lists top competitions (leagues/cups). 
- [x] Should also have an option to view all competitions which is a link to "/competitions/all". 
- [x] "/competitions/all" should return a list of all competitions API-Football supports. 
- [x] Should sort the competitions by top competitions, world competitions, and rest of the world competitions. 
- [x] Each sub-group should be order alphabetically by country name. 
- [x] Each competition should be a link to "/competitions/id/:id".
- [x] Be able to filter competitions by name