### PR TITLE
web - remove Euro 2024 and Copa America priority

### DIFF
--- a/web/src/common/constants.ts
+++ b/web/src/common/constants.ts
@@ -1,5 +1,5 @@
 // Disable this list for now to show UEFA Euros 2024 games first
-// export const TOP_COMPS_IDS: number[] = [2, 3, 39, 45, 48, 61, 78, 135, 140, 253, 848];
+export const TOP_COMPS_IDS: number[] = [2, 3, 39, 45, 48, 61, 78, 135, 140, 253, 848];
 
 // UEFA Euros 2024 & Copa America
-export const TOP_COMPS_IDS: number[] = [4, 9];
+// export const TOP_COMPS_IDS: number[] = [4, 9];

--- a/web/src/layouts/navbar/navbar.tsx
+++ b/web/src/layouts/navbar/navbar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { NavLink } from "react-router-dom";
-import { Calendar, Globe, Menu, Trophy } from "lucide-react";
+import { Calendar, Menu, Trophy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetDescription, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { ThemeToggleComponent } from "./theme-toggle/theme-toggle";
@@ -83,30 +83,6 @@ const NavbarNavContentComponent = (props: INavbarNavComponentProps) => {
                     >
                         <Trophy className="lg:hidden" />
                         Competitions
-                    </NavLink>
-                    <NavLink
-                        to="/competitions/id/9"
-                        onClick={() => closeSheet()}
-                        className={({ isActive }) =>
-                            isActive
-                                ? "flex gap-2 items-center text-nowrap w-full p-2 rounded-md bg-muted font-medium"
-                                : "flex gap-2 items-center text-nowrap w-full p-2 rounded-md hover:bg-muted focus:bg-muted font-medium"
-                        }
-                    >
-                        <Globe className="lg:hidden" />
-                        Copa America 2024
-                    </NavLink>
-                    <NavLink
-                        to="/competitions/id/4"
-                        onClick={() => closeSheet()}
-                        className={({ isActive }) =>
-                            isActive
-                                ? "flex gap-2 items-center text-nowrap w-full p-2 rounded-md bg-muted font-medium"
-                                : "flex gap-2 items-center text-nowrap w-full p-2 rounded-md hover:bg-muted focus:bg-muted font-medium"
-                        }
-                    >
-                        <Globe className="lg:hidden" />
-                        UEFA Euro 2024
                     </NavLink>
                     <MoreLinksWrapperComponent closeSheet={closeSheet} />
                 </section>


### PR DESCRIPTION
- Removed Euro 2024 and Copa America from the navbar
- Revert back to showing the top leagues in world before other lists